### PR TITLE
Fix duplicated reverse image search links

### DIFF
--- a/8chan-x.user.js
+++ b/8chan-x.user.js
@@ -993,7 +993,7 @@ if (setting("searchbyimagelinks")) {
 		}
 	];
 
-	var posts = document.getElementsByClassName("post-image");
+	var posts = document.querySelectorAll("img.post-image");
 	for (var pIdx in posts) {
 		for (var sbpIdx in sbp) {
 			try {


### PR DESCRIPTION
Sometimes <canvas> elements have the "post-image" class,
so they get empty reverse image search links.
This is especially annoying if you use the "Unanimate GIFs" option.
Simply restricting the function to <img> elements solves the problem.
